### PR TITLE
feat: add authors section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # ECMAScript proposal: JavaScript standard library UUID
 
-Champions: [Benjamin Coe](https://github.com/bcoe)
-
 Status: early draft, never presented to TC39
+
+## Authors
+
+* Benjamin Coe ([@bcoe](https://github.com/bcoe))
+* Robert Kieffer ([@broofa](https://github.com/broofa))
+* Christoph Tavan ([@ctavan](https://github.com/ctavan))
 
 ## Synopsis
 


### PR DESCRIPTION
* add primary authors to author's section.
* remove champion from doc for time being, until we're getting closer to actually presenting something.

fixes #12 